### PR TITLE
feat: renaming subcommand "/create custom" to "/create activity", fixing comments (closes #17)

### DIFF
--- a/lib/core/data/enums/activity_type.dart
+++ b/lib/core/data/enums/activity_type.dart
@@ -9,8 +9,8 @@ enum LFGActivityType {
   ///
   /// See [Activity.custom] for more info.
   ///
-  /// All custom activities registers in `/create custom` command.
-  custom,
+  /// All custom activities registers in `/create activity` command.
+  activity,
 
   /// Dungeon activity, stored in `/activities/dungeons.json` file.
   ///

--- a/lib/core/data/enums/activity_type.dart
+++ b/lib/core/data/enums/activity_type.dart
@@ -1,5 +1,5 @@
 /// Enum for activity types.
-enum LFGActivityType {
+enum LFGType {
 
   /// Custom activity, stored in `/activities/custom.json` file.
   ///
@@ -14,7 +14,7 @@ enum LFGActivityType {
 
   /// Dungeon activity, stored in `/activities/dungeons.json` file.
   ///
-  /// Main difference from [LFGActivityType.activity] is that it has fixed number of members: 3.
+  /// Main difference from [LFGType.activity] is that it has fixed number of members: 3.
   ///
   /// See [Activity.dungeon] for more info.
   ///
@@ -23,7 +23,7 @@ enum LFGActivityType {
 
   /// Raid activity, stored in `/activities/raids.json` file.
   ///
-  /// Main difference from [LFGActivityType.activity] is that it has fixed number of members: 6.
+  /// Main difference from [LFGType.activity] is that it has fixed number of members: 6.
   ///
   /// See [Activity.raid] for more info.
   ///

--- a/lib/core/data/enums/activity_type.dart
+++ b/lib/core/data/enums/activity_type.dart
@@ -14,7 +14,7 @@ enum LFGActivityType {
 
   /// Dungeon activity, stored in `/activities/dungeons.json` file.
   ///
-  /// Main difference from [LFGActivityType.custom] is that it has fixed number of members: 3.
+  /// Main difference from [LFGActivityType.activity] is that it has fixed number of members: 3.
   ///
   /// See [Activity.dungeon] for more info.
   ///
@@ -23,7 +23,7 @@ enum LFGActivityType {
 
   /// Raid activity, stored in `/activities/raids.json` file.
   ///
-  /// Main difference from [LFGActivityType.custom] is that it has fixed number of members: 6.
+  /// Main difference from [LFGActivityType.activity] is that it has fixed number of members: 6.
   ///
   /// See [Activity.raid] for more info.
   ///

--- a/lib/core/data/models/activity.dart
+++ b/lib/core/data/models/activity.dart
@@ -30,8 +30,8 @@ abstract interface class Activity {
 
   /// Type of activity
   ///
-  /// See [LFGActivityType] for more info.
-  LFGActivityType get type;
+  /// See [LFGType] for more info.
+  LFGType get type;
 }
 
 class _JsonActivity implements Activity {
@@ -40,7 +40,7 @@ class _JsonActivity implements Activity {
     required this.maxMembers,
     required this.bannerUrl,
     required this.enabled,
-    this.type = LFGActivityType.activity,
+    this.type = LFGType.activity,
   });
 
   factory _JsonActivity.dungeon(Map<String, Object?> json) {
@@ -49,7 +49,7 @@ class _JsonActivity implements Activity {
       maxMembers: 3,
       bannerUrl: json['banner_url']! as String,
       enabled: json['enabled']! as bool,
-      type: LFGActivityType.dungeon,
+      type: LFGType.dungeon,
     );
   }
 
@@ -59,7 +59,7 @@ class _JsonActivity implements Activity {
       maxMembers: 6,
       bannerUrl: json['banner_url']! as String,
       enabled: json['enabled']! as bool,
-      type: LFGActivityType.raid,
+      type: LFGType.raid,
     );
   }
 
@@ -76,5 +76,5 @@ class _JsonActivity implements Activity {
   final bool enabled;
 
   @override
-  final LFGActivityType type;
+  final LFGType type;
 }

--- a/lib/core/data/models/activity.dart
+++ b/lib/core/data/models/activity.dart
@@ -40,7 +40,7 @@ class _JsonActivity implements Activity {
     required this.maxMembers,
     required this.bannerUrl,
     required this.enabled,
-    this.type = LFGActivityType.custom,
+    this.type = LFGActivityType.activity,
   });
 
   factory _JsonActivity.dungeon(Map<String, Object?> json) {

--- a/lib/features/command_manager/command_manager.dart
+++ b/lib/features/command_manager/command_manager.dart
@@ -10,13 +10,13 @@ import '../../core/utils/loaders/bot_settings.dart';
 /// * [builder] is a function that returns an [ApplicationCommandBuilder] object. Use this object to create a new command.
 /// * [handlers] is a map of handlers for the command. The key is a string that represents the name of the command. \
 ///
-/// To example, we have a /create command with three subcommands: raid, dungeon, custom. \
+/// To example, we have a /create command with three subcommands: raid, dungeon, activity. \
 /// So, we can create a map of handlers for this command:
 /// ```dart
 /// {
 ///  'raid': (interaction) => _createActivityHandler(interaction, LFGActivityType.raid),
 ///  'dungeon': (interaction) => _createActivityHandler(interaction, LFGActivityType.dungeon),
-///  'custom': (interaction) => _createActivityHandler(interaction, LFGActivityType.custom),
+///  'activity': (interaction) => _createActivityHandler(interaction, LFGActivityType.activity),
 ///  }
 ///  ```
 ///  This map will be used to match the name of the command with the handler.

--- a/lib/features/command_manager/command_manager.dart
+++ b/lib/features/command_manager/command_manager.dart
@@ -14,9 +14,9 @@ import '../../core/utils/loaders/bot_settings.dart';
 /// So, we can create a map of handlers for this command:
 /// ```dart
 /// {
-///  'raid': (interaction) => _createActivityHandler(interaction, LFGActivityType.raid),
-///  'dungeon': (interaction) => _createActivityHandler(interaction, LFGActivityType.dungeon),
-///  'activity': (interaction) => _createActivityHandler(interaction, LFGActivityType.activity),
+///  'raid': (interaction) => _createActivityHandler(interaction, LFGType.raid),
+///  'dungeon': (interaction) => _createActivityHandler(interaction, LFGType.dungeon),
+///  'activity': (interaction) => _createActivityHandler(interaction, LFGType.activity),
 ///  }
 ///  ```
 ///  This map will be used to match the name of the command with the handler.

--- a/lib/features/create/handler/create_handle.dart
+++ b/lib/features/create/handler/create_handle.dart
@@ -12,10 +12,10 @@ import '../../lfg_manager/lfg_manager.dart';
 ///
 /// This command is used for creating new LFG posts.
 ///
-/// This command has 3 subcommands: raid, dungeon, custom.
+/// This command has 3 subcommands: raid, dungeon, activity.
 /// * raid - creates new LFG post for raid activity.
 /// * dungeon - creates new LFG post for dungeon activity.
-/// * custom - creates new LFG post for custom activity.
+/// * activity - creates new LFG post for custom activity.
 CommandCreator createCategoryCommands() {
   return (
     builder: _createAll,

--- a/lib/features/create/handler/create_handle.dart
+++ b/lib/features/create/handler/create_handle.dart
@@ -22,7 +22,7 @@ CommandCreator createCategoryCommands() {
     handlers: {
       'create raid': _createActivityHandler,
       'create dungeon': _createActivityHandler,
-      'create custom': _createActivityHandler,
+      'create activity': _createActivityHandler,
     }
   );
 }
@@ -37,7 +37,7 @@ Future<void> _createActivityHandler(InteractionCreateEvent<ApplicationCommandInt
   final manager = Context.root.get<LFGManager>('manager');
   final settings = Context.root.get<BotSettings>('settings');
 
-  // create command always has 1 subcommand: raid, dungeon, custom.
+  // create command always has 1 subcommand: raid, dungeon, activity.
   // So we can just use first to get options of subcommand.
   // All options for `/create` command are equal for all subcommands.
   final createOptions = interaction.interaction.data.options!.first.options!;

--- a/lib/features/create/handler/create_handle.dart
+++ b/lib/features/create/handler/create_handle.dart
@@ -62,7 +62,7 @@ Future<void> _createActivityHandler(InteractionCreateEvent<ApplicationCommandInt
   );
 }
 
-List<CommandOptionChoiceBuilder<String>>? _getActivityChoices(LFGActivityType type) {
+List<CommandOptionChoiceBuilder<String>>? _getActivityChoices(LFGType type) {
   final settings = Context.root.get<BotSettings>('settings');
   final activities = settings.activityData.activities.where((e) => e.type == type);
 
@@ -83,7 +83,7 @@ ApplicationCommandBuilder _createAll() {
     name: 'create',
     description: 'Создать активность',
     type: ApplicationCommandType.chatInput,
-    options: LFGActivityType.values
+    options: LFGType.values
         .map((type) => CommandOptionBuilder.subCommand(
               name: type.name,
               description: 'Создать сбор на активность',

--- a/lib/features/lfg_manager/data/models/register_activity.dart
+++ b/lib/features/lfg_manager/data/models/register_activity.dart
@@ -48,7 +48,7 @@ base class LFGPostBuilder implements ILFGPostBuilder {
     required this.name,
     required this.maxMembers,
     this.enabled = true,
-    this.type = LFGActivityType.activity,
+    this.type = LFGType.activity,
   });
 
   /// Creates new LFG post builder using data from [Activity].
@@ -110,7 +110,7 @@ base class LFGPostBuilder implements ILFGPostBuilder {
 
   /// Type of LFG activity.
   @override
-  final LFGActivityType type;
+  final LFGType type;
 
   @override
   bool operator ==(Object other) =>
@@ -145,7 +145,7 @@ base class LFGPostBuilder implements ILFGPostBuilder {
     bool? enabled,
     String? name,
     int? maxMembers,
-    LFGActivityType? type,
+    LFGType? type,
   }) {
     return LFGPostBuilder(
       authorID: authorID ?? this.authorID,
@@ -234,5 +234,5 @@ base class LFGPost implements ILFGPost {
   final Snowflake messageID;
 
   @override
-  final LFGActivityType type;
+  final LFGType type;
 }

--- a/lib/features/lfg_manager/data/models/register_activity.dart
+++ b/lib/features/lfg_manager/data/models/register_activity.dart
@@ -48,7 +48,7 @@ base class LFGPostBuilder implements ILFGPostBuilder {
     required this.name,
     required this.maxMembers,
     this.enabled = true,
-    this.type = LFGActivityType.custom,
+    this.type = LFGActivityType.activity,
   });
 
   /// Creates new LFG post builder using data from [Activity].


### PR DESCRIPTION
Renamed subcommand 'create custom' to 'create activity' so it's not confusing anymore. Also fixed the comments to match the actual commands.