### PR TITLE
feat: core settings in platform environments (closes #13)

### DIFF
--- a/bin/lfg_bot.dart
+++ b/bin/lfg_bot.dart
@@ -1,25 +1,18 @@
 import 'dart:async';
-import 'dart:ffi';
 import 'dart:io';
 
 import 'package:l/l.dart';
-import 'package:lfg_bot/core/bot/core.dart';
 import 'package:lfg_bot/core/const/exceptions.dart';
-import 'package:lfg_bot/core/l10n/generated/messages_all_locales.dart';
-import 'package:lfg_bot/core/utils/context/context.dart';
-import 'package:lfg_bot/core/utils/database/tables/posts.dart';
-import 'package:lfg_bot/core/utils/loaders/bot_settings.dart';
+import 'package:lfg_bot/core/utils/config.dart';
+import 'package:lfg_bot/core/utils/dependencies.dart';
 import 'package:lfg_bot/features/create/handler/create_handle.dart';
 import 'package:lfg_bot/features/delete/handler/delete_handler.dart';
 import 'package:lfg_bot/features/edit/handler/edit_handler.dart';
 import 'package:lfg_bot/features/join/handler/join_handle.dart';
 import 'package:lfg_bot/features/leave/handler/leave_handler.dart';
-import 'package:lfg_bot/features/lfg_manager/lfg_manager.dart';
-import 'package:lfg_bot/features/lfg_manager/message_handler.dart';
-import 'package:lfg_bot/features/scheduler/scheduler.dart';
 
 void main(List<String> arguments) => runZonedGuarded(
-      runner,
+      runBot,
       zoneSpecification: ZoneSpecification(
         print: (self, parent, zone, message) => l.i('[${DateTime.now()}] $message'),
       ),
@@ -34,54 +27,53 @@ void main(List<String> arguments) => runZonedGuarded(
       },
     );
 
-Future<void> runner() async {
-  // load bot settings
-  final settings = BotSettings.fromFile('data/bot_settings.json');
+void runBot() => Future(() async {
+      final config = Config.fromEnvironment();
+      final dependencies = await Dependencies.initialize(config: config);
 
-  // initialize database
-  _openSqlite();
-  final database = PostsDatabase();
+      await dependencies.commandManager.registerCommand(createCategoryCommands());
+      await dependencies.commandManager.registerCommand(deleteCommand());
+      await dependencies.commandManager.registerCommand(editComponentHandler());
 
-  // initialize bot
-  final core = await LFGBotCore.initialize();
+      await dependencies.commandManager.registerComponent(joinComponentHandler());
+      await dependencies.commandManager.registerComponent(leaveComponentHandler());
+    });
 
-  final isLocaleInitialized = await initializeMessages(settings.locale);
-  if (!isLocaleInitialized) throw FatalException('Failed to initialize locale: ${settings.locale}');
-
-  final lfgManager = LFGManager(database: database, messageHandler: const MessageHandler());
-  final scheduler = PostScheduler(database: database, core: core, lfgManager: lfgManager);
-
-  Context.setRoot(
-    Context.from({
-      'settings': settings,
-      'core': core,
-      'db': database,
-      'manager': lfgManager,
-      'scheduler': scheduler,
-    }),
-  );
-
-  await core.commandManager.registerCommand(createCategoryCommands());
-  await core.commandManager.registerCommand(deleteCommand());
-  await core.commandManager.registerCommand(editComponentHandler());
-
-  await core.commandManager.registerComponent(joinComponentHandler());
-  await core.commandManager.registerComponent(leaveComponentHandler());
-}
-
-DynamicLibrary _openSqlite() {
-  return DynamicLibrary.open(_sqliteLibraryPath);
-}
-
-String get _sqliteLibraryPath {
-  final scriptDir = File(Platform.script.toFilePath()).parent.parent;
-  final libraryNextToScript = File('${scriptDir.path}/data/dependencies');
-  if (Platform.isWindows) return '${libraryNextToScript.path}/dll/sqlite3.dll';
-  if (Platform.isLinux) return '${libraryNextToScript.path}/so/sqlite3';
-  if (Platform.isMacOS) return '${libraryNextToScript.path}/osx/sqlite3_arm64';
-
-  throw FatalException('Unsupported platform: ${Platform.operatingSystem}');
-}
+@Deprecated('Use runBot instead')
+// Future<void> runner() async {
+//   // load bot settings
+//   final settings = BotSettings.fromFile('data/bot_settings.json');
+//
+//   // initialize database
+//   _openSqlite();
+//   final database = PostsDatabase();
+//
+//   // initialize bot
+//   final core = await LFGBotCore.initialize(token: settings.botConfig.botToken);
+//
+//   final isLocaleInitialized = await initializeMessages(settings.locale);
+//   if (!isLocaleInitialized) throw FatalException('Failed to initialize locale: ${settings.locale}');
+//
+//   final lfgManager = LFGManager(database: database, messageHandler: const MessageHandler());
+//   final scheduler = PostScheduler(database: database, core: core, lfgManager: lfgManager);
+//
+//   Context.setRoot(
+//     Context.from({
+//       'settings': settings,
+//       'core': core,
+//       'db': database,
+//       'manager': lfgManager,
+//       'scheduler': scheduler,
+//     }),
+//   );
+//
+//   await core.commandManager.registerCommand(createCategoryCommands());
+//   await core.commandManager.registerCommand(deleteCommand());
+//   await core.commandManager.registerCommand(editComponentHandler());
+//
+//   await core.commandManager.registerComponent(joinComponentHandler());
+//   await core.commandManager.registerComponent(leaveComponentHandler());
+// }
 
 Future<String> getCPUArchitecture() async {
   if (Platform.isWindows) {

--- a/lib/core/bot/core.dart
+++ b/lib/core/bot/core.dart
@@ -1,7 +1,7 @@
 import 'package:nyxx/nyxx.dart';
 
 import '../../features/command_manager/command_manager.dart';
-import '../utils/loaders/bot_settings.dart';
+import '../utils/config.dart';
 
 class LFGBotCore {
   const LFGBotCore({
@@ -20,10 +20,10 @@ class LFGBotCore {
   final CommandManager commandManager;
 
   /// Initializes connection to Discord using WebSocket and syncs interactions.
-  static Future<LFGBotCore> initialize() async {
+  static Future<LFGBotCore> initialize({required Config config}) async {
     // create bot with intents and register plugins
     final bot = await Nyxx.connectGateway(
-      BotSettings.instance.botConfig.botToken,
+      config.token,
       GatewayIntents.allUnprivileged | GatewayIntents.guildMessages,
       options: GatewayClientOptions(
         loggerName: 'LFG Bot',
@@ -37,7 +37,7 @@ class LFGBotCore {
 
     return LFGBotCore(
       bot: bot,
-      commandManager: CommandManager(bot: bot),
+      commandManager: CommandManager(bot: bot, server: config.server),
     );
   }
 }

--- a/lib/core/const/exceptions.dart
+++ b/lib/core/const/exceptions.dart
@@ -32,7 +32,21 @@ class _FatalException implements FatalException {
   }
 }
 
+base class EnvironmentVariableMissing implements FatalException {
+  const EnvironmentVariableMissing(this.variableName);
+
+  final String variableName;
+
+  @override
+  int get exitCode => ExitCode.config.code;
+
+  @override
+  String toString() => 'Environment variable "$variableName" is missing, please set it.';
+}
+
+@Deprecated('No more config files used')
 base class ConfigFileMissing implements FatalException {
+  @Deprecated('No more config files used')
   const ConfigFileMissing(
     this.configFileName, {
     this.configPath,

--- a/lib/core/const/exceptions.dart
+++ b/lib/core/const/exceptions.dart
@@ -44,9 +44,7 @@ base class EnvironmentVariableMissing implements FatalException {
   String toString() => 'Environment variable "$variableName" is missing, please set it.';
 }
 
-@Deprecated('No more config files used')
 base class ConfigFileMissing implements FatalException {
-  @Deprecated('No more config files used')
   const ConfigFileMissing(
     this.configFileName, {
     this.configPath,

--- a/lib/core/utils/config.dart
+++ b/lib/core/utils/config.dart
@@ -1,0 +1,54 @@
+import 'dart:io';
+
+import 'package:nyxx/nyxx.dart';
+
+import '../const/exceptions.dart';
+
+/// {@template Config}
+///
+/// Core configuration for bot necessary for it's work.
+///
+/// {@endtemplate}
+final class Config {
+  /// {@macro Config}
+  const Config({
+    required this.token,
+    required this.serverId,
+  });
+
+  /// Creates a new [Config] instance from environment variables.
+  ///
+  /// Will throw [EnvironmentVariableMissing] if any of the required variables are missing.
+  factory Config.fromEnvironment() {
+    final env = Platform.environment;
+
+    return Config(
+      token: _read('OMEGA_TOKEN', env),
+      serverId: int.parse(_read('OMEGA_SERVER_ID', env)),
+    );
+  }
+
+  static String _read(String key, Map<String, String> env) {
+    final value = env[key];
+    if (value == null) {
+      throw EnvironmentVariableMissing(key);
+    }
+
+    return value;
+  }
+
+  /// Discord bot token.
+  final String token;
+
+  /// {@template Config.ServerId}
+  ///
+  /// Discord server id where bot is located.
+  ///
+  /// This is necessary, because bot will only register commands in this server.
+  ///
+  /// {@endtemplate}
+  final int serverId;
+
+  /// {@macro Config.ServerId}
+  Snowflake get server => Snowflake(serverId);
+}

--- a/lib/core/utils/context/context.dart
+++ b/lib/core/utils/context/context.dart
@@ -27,6 +27,7 @@ abstract final class Context {
   /// Returns value from context.
   Object operator [](String key);
 
+  @Deprecated('Use Dependencies instead')
   T get<T>(String key) => this[key] as T;
 
   Map<String, Object> toMap();
@@ -47,6 +48,7 @@ final class _Context implements Context {
   @override
   void operator []=(String key, Object value) => _map[key] = value;
 
+  @Deprecated('Use Dependencies instead')
   @override
   T get<T>(String key) {
     final value = _map[key];
@@ -71,6 +73,7 @@ final class UnmodifiableContext implements Context {
   @override
   Object operator [](String key) => _context[key];
 
+  @Deprecated('Use Dependencies instead')
   @override
   T get<T>(String key) => this[key] as T;
 

--- a/lib/core/utils/dependencies.dart
+++ b/lib/core/utils/dependencies.dart
@@ -1,0 +1,97 @@
+import 'dart:ffi';
+import 'dart:io';
+
+import '../../features/command_manager/command_manager.dart';
+import '../../features/lfg_manager/lfg_manager.dart';
+import '../../features/lfg_manager/message_handler.dart';
+import '../../features/scheduler/scheduler.dart';
+import '../bot/core.dart';
+import '../const/exceptions.dart';
+import 'config.dart';
+import 'database/tables/posts.dart';
+
+DynamicLibrary _loadSqlite() {
+  return DynamicLibrary.open(_sqliteLibraryPath);
+}
+
+String get _sqliteLibraryPath {
+  final scriptDir = File(Platform.script.toFilePath()).parent.parent;
+  final libraryNextToScript = File('${scriptDir.path}/data/dependencies');
+  if (Platform.isWindows) return '${libraryNextToScript.path}/dll/sqlite3.dll';
+  if (Platform.isLinux) return '${libraryNextToScript.path}/so/sqlite3';
+  if (Platform.isMacOS) return '${libraryNextToScript.path}/osx/sqlite3_arm64';
+
+  throw FatalException('Unsupported platform: ${Platform.operatingSystem}');
+}
+
+/// {@template Dependencies}
+///
+/// Dependencies for the application.
+/// Contains all core services for bot work.
+///
+/// {@endtemplate}
+final class Dependencies {
+  /// {@macro Dependencies}
+  const Dependencies._({
+    required this.config,
+    required this.core,
+    required this.commandManager,
+    required this.postScheduler,
+    required this.postsDatabase,
+    required this.lfgManager,
+  });
+
+  /// Stores instance of [Dependencies].
+  static Dependencies? _instance;
+
+  /// {@macro Dependencies}
+  static Dependencies get i => instance;
+
+  /// {@macro Dependencies}
+  static Dependencies get instance {
+    if (_instance == null) {
+      throw Exception('Dependencies not initialized. Call Dependencies.initialize first.');
+    }
+
+    return _instance!;
+  }
+
+  /// Initializes [Dependencies] with provided [Config].
+  static Future<Dependencies> initialize({required Config config}) async {
+    if (_instance != null) {
+      throw Exception('Dependencies already initialized. Use Dependencies.instance to get instance.');
+    }
+
+    _loadSqlite();
+
+    final core = await LFGBotCore.initialize(config: config);
+
+    final postsDatabase = PostsDatabase();
+
+    final lfgManager = LFGManager(database: postsDatabase, messageHandler: const MessageHandler());
+
+    final dep = Dependencies._(
+      config: config,
+      core: core,
+      postsDatabase: postsDatabase,
+      lfgManager: lfgManager,
+      commandManager: core.commandManager,
+      postScheduler: PostScheduler(database: postsDatabase, core: core, lfgManager: lfgManager),
+    );
+
+    return _instance = dep;
+  }
+
+  /// {@macro Config}
+  final Config config;
+
+  final LFGBotCore core;
+
+  final CommandManager commandManager;
+
+  final PostScheduler postScheduler;
+
+  final PostsDatabase postsDatabase;
+
+  final LFGManager lfgManager;
+}

--- a/lib/core/utils/dependencies.dart
+++ b/lib/core/utils/dependencies.dart
@@ -93,5 +93,5 @@ final class Dependencies {
 
   final PostsDatabase postsDatabase;
 
-  final LFGManager lfgManager;
+  final ILFGManager lfgManager;
 }

--- a/lib/core/utils/loaders/activity_data.dart
+++ b/lib/core/utils/loaders/activity_data.dart
@@ -1,11 +1,13 @@
 import 'dart:convert';
 import 'dart:io';
 
-import '../../data/models/activity.dart';
 import '../../const/exceptions.dart';
+import '../../data/models/activity.dart';
 
+@Deprecated('Migrate to settings in SQL')
 abstract final class ActivityData {
 
+  @Deprecated('Migrate to settings in SQL')
   /// Loads activities from file.
   factory ActivityData.fromFiles({
     required String raidsPath,

--- a/lib/core/utils/loaders/bot_settings.dart
+++ b/lib/core/utils/loaders/bot_settings.dart
@@ -5,7 +5,9 @@ import '../../const/exceptions.dart';
 import 'activity_data.dart';
 import 'config_data.dart';
 
+@Deprecated('Migrate to settings in SQL')
 abstract final class BotSettings {
+  @Deprecated('Migrate to settings in SQL')
   factory BotSettings.fromFile(String path) {
     final botSettingsFile = File(path);
     if (!botSettingsFile.existsSync()) {

--- a/lib/features/command_manager/command_manager.dart
+++ b/lib/features/command_manager/command_manager.dart
@@ -3,7 +3,6 @@ import 'dart:async';
 import 'package:nyxx/nyxx.dart';
 
 import '../../core/const/command_exceptions.dart';
-import '../../core/utils/loaders/bot_settings.dart';
 
 /// Typedef for creating a new command with a handler.
 ///
@@ -50,18 +49,22 @@ base class CommandManager {
   /// Creates a new [CommandManager] instance for a [bot].
   CommandManager({
     required NyxxGateway bot,
-  }) : _bot = bot {
+    required Snowflake server,
+  })  : _bot = bot,
+        _server = server {
     _listenInteractions();
     _listenButtons();
     _listenModals();
   }
+
+  final Snowflake _server;
 
   // Bot instance which used to manage interactions.
   final NyxxGateway _bot;
 
   // Partial application command manager for current guild, where bot is located and should work.
   // If bot will be invited to another guild, then bot will not work.
-  PartialApplicationCommand get _guildManager => _bot.commands[Snowflake(BotSettings.instance.botConfig.serverID)];
+  PartialApplicationCommand get _guildManager => _bot.commands[_server];
 
   // Map of registered commands.
   // Key is a full command name, value is a function which handles command.

--- a/lib/features/create/handler/create_handle.dart
+++ b/lib/features/create/handler/create_handle.dart
@@ -2,11 +2,11 @@ import 'package:nyxx/nyxx.dart' hide Activity;
 
 import '../../../core/data/enums/activity_type.dart';
 import '../../../core/utils/context/context.dart';
+import '../../../core/utils/dependencies.dart';
 import '../../../core/utils/loaders/bot_settings.dart';
 import '../../../core/utils/time_convert.dart';
 import '../../command_manager/command_manager.dart';
 import '../../lfg_manager/data/models/register_activity.dart';
-import '../../lfg_manager/lfg_manager.dart';
 
 /// Builds `/create` command.
 ///
@@ -34,7 +34,8 @@ Future<void> _createActivityHandler(InteractionCreateEvent<ApplicationCommandInt
   final userName = member.nick ?? member.user?.username;
   print('User "$userName" is trying to create new raid LFG post');
 
-  final manager = Context.root.get<LFGManager>('manager');
+
+  final manager = Dependencies.i.lfgManager;
   final settings = Context.root.get<BotSettings>('settings');
 
   // create command always has 1 subcommand: raid, dungeon, activity.

--- a/lib/features/delete/handler/delete_handler.dart
+++ b/lib/features/delete/handler/delete_handler.dart
@@ -1,9 +1,7 @@
 import 'package:nyxx/nyxx.dart';
 
-import '../../../core/utils/context/context.dart';
-import '../../../core/utils/database/tables/posts.dart';
+import '../../../core/utils/dependencies.dart';
 import '../../command_manager/command_manager.dart';
-import '../../lfg_manager/lfg_manager.dart';
 
 CommandCreator deleteCommand() {
   return (
@@ -34,7 +32,8 @@ Future<void> _deleteHandler(InteractionCreateEvent<ApplicationCommandInteraction
     return;
   }
 
-  final database = Context.root.get<PostsDatabase>('db');
+
+  final database = Dependencies.i.postsDatabase;
   final postData = await database.findPost(message.value);
 
   // if post can't be found in database, then it's not LFG
@@ -60,7 +59,8 @@ Future<void> _deleteHandler(InteractionCreateEvent<ApplicationCommandInteraction
     return;
   }
 
-  final lfgManager = Context.root.get<ILFGManager>('manager');
+
+  final lfgManager = Dependencies.i.lfgManager;
   await lfgManager.delete(message.value);
 
   await interaction.interaction.respond(

--- a/lib/features/join/handler/join_handle.dart
+++ b/lib/features/join/handler/join_handle.dart
@@ -1,9 +1,8 @@
 import 'package:nyxx/nyxx.dart';
 
 import '../../../core/const/command_exceptions.dart';
-import '../../../core/utils/context/context.dart';
+import '../../../core/utils/dependencies.dart';
 import '../../command_manager/command_manager.dart';
-import '../../lfg_manager/lfg_manager.dart';
 
 ComponentCreator joinComponentHandler() => (
       customID: 'join',
@@ -14,7 +13,7 @@ Future<void> _handleJoinInteraction(InteractionCreateEvent<MessageComponentInter
   final messageID = event.interaction.message?.id;
   if (messageID == null) return;
 
-  final lfgManager = Context.root.get<ILFGManager>('manager');
+  final lfgManager = Dependencies.i.lfgManager;
 
   try {
     await lfgManager.addMemberTo(event.interaction.message!, event.interaction.member!.user!);

--- a/lib/features/leave/handler/leave_handler.dart
+++ b/lib/features/leave/handler/leave_handler.dart
@@ -1,9 +1,8 @@
 import 'package:nyxx/nyxx.dart';
 
 import '../../../core/const/command_exceptions.dart';
-import '../../../core/utils/context/context.dart';
+import '../../../core/utils/dependencies.dart';
 import '../../command_manager/command_manager.dart';
-import '../../lfg_manager/lfg_manager.dart';
 
 ComponentCreator leaveComponentHandler() => (
       customID: 'leave',
@@ -14,7 +13,7 @@ Future<void> _handleLeaveInteraction(InteractionCreateEvent<MessageComponentInte
   final messageID = event.interaction.message?.id;
   if (messageID == null) return;
 
-  final lfgManager = Context.root.get<ILFGManager>('manager');
+  final lfgManager = Dependencies.i.lfgManager;
 
   try {
     await lfgManager.removeMemberFrom(event.interaction.message!, event.interaction.member!.user!);

--- a/lib/features/lfg_manager/lfg_manager.dart
+++ b/lib/features/lfg_manager/lfg_manager.dart
@@ -3,12 +3,11 @@ import 'dart:async';
 import 'package:drift/drift.dart';
 import 'package:nyxx/nyxx.dart';
 
-import '../../core/bot/core.dart';
 import '../../core/const/command_exceptions.dart';
 import '../../core/utils/context/context.dart';
 import '../../core/utils/database/tables/posts.dart';
+import '../../core/utils/dependencies.dart';
 import '../../core/utils/loaders/bot_settings.dart';
-import '../scheduler/scheduler.dart';
 import 'data/models/register_activity.dart';
 import 'message_handler.dart';
 
@@ -84,7 +83,7 @@ final class LFGManager implements ILFGManager {
       final dbID = await _database.insertPost(dbPost);
       await addMemberTo(discordLfgPost, interaction.interaction.member!.user!, fromCreate: true);
 
-      Context.root.get<PostScheduler>('scheduler').schedulePost(
+      Dependencies.i.postScheduler.schedulePost(
             startTime: dbPost.date.value,
             postID: dbPost.postMessageId.value,
           );
@@ -108,7 +107,7 @@ final class LFGManager implements ILFGManager {
     final post = await _database.findPost(id);
     if (post == null) throw CantRespondException('LFG $id не найден');
 
-    final bot = Context.root.get<LFGBotCore>('core').bot;
+    final bot = Dependencies.i.core.bot;
     final settings = Context.root.get<BotSettings>('settings');
 
     final channel = await bot.channels.fetch(Snowflake(settings.botConfig.lfgChannel));
@@ -126,7 +125,7 @@ final class LFGManager implements ILFGManager {
     await (channel as GuildTextChannel).messages.fetch(Snowflake(post.postMessageId)).then((value) => value.delete());
 
     print('[LFGManager] Unsheduling post with id $id');
-    Context.root.get<PostScheduler>('scheduler').cancelPost(postID: id);
+    Dependencies.i.postScheduler.cancelPost(postID: id);
   }
 
   @override
@@ -158,7 +157,7 @@ final class LFGManager implements ILFGManager {
     );
 
     if (unixTime != null) {
-      Context.root.get<PostScheduler>('scheduler').editTime(
+      Dependencies.i.postScheduler.editTime(
             postID: post.postMessageId,
             newTime: DateTime.fromMillisecondsSinceEpoch(unixTime),
           );
@@ -191,7 +190,7 @@ final class LFGManager implements ILFGManager {
     // all good, add user to database
     await _database.addMember(message.id.value, user.id.value);
 
-    final botCore = Context.root.get<LFGBotCore>('core');
+    final botCore = Dependencies.i.core;
     for (int index = 0; index < membersIDS.length; index++) {
       final user = await botCore.bot.users.fetch(Snowflake(membersIDS[index]));
       members[index] = user.globalName ?? user.username;
@@ -222,7 +221,7 @@ final class LFGManager implements ILFGManager {
     final membersIDS = await _database.getMembersForPost(message.id.value);
     final members = List<String>.generate(membersIDS.length, (index) => '$index gen');
 
-    final botCore = Context.root.get<LFGBotCore>('core');
+    final botCore = Dependencies.i.core;
     for (int index = 0; index < membersIDS.length; index++) {
       final user = await botCore.bot.users.fetch(Snowflake(membersIDS[index]));
       members[index] = user.globalName ?? user.username;

--- a/lib/features/lfg_manager/message_handler.dart
+++ b/lib/features/lfg_manager/message_handler.dart
@@ -3,9 +3,9 @@ import 'dart:math';
 
 import 'package:nyxx/nyxx.dart' hide Activity;
 
-import '../../core/bot/core.dart';
 import '../../core/data/models/activity.dart';
 import '../../core/utils/context/context.dart';
+import '../../core/utils/dependencies.dart';
 import '../../core/utils/loaders/bot_settings.dart';
 import 'data/models/register_activity.dart';
 
@@ -48,7 +48,7 @@ final class MessageHandler implements IMessageHandler {
   ];
 
   Future<MessageBuilder> _buildLFGPost(ILFGPostBuilder builder) async {
-    final bot = Context.root.get<LFGBotCore>('core').bot;
+    final bot = Dependencies.i.core.bot;
     final user = await bot.users.get(builder.authorID);
 
     final embedBuilder = EmbedBuilder()


### PR DESCRIPTION
This PR is a first part of moving all bot settings from unfriendly places to a better one. 

Overview:
1. Core settings such a bot token and server id was moved into platform env. That means, old json configs will be removed ASAP
2. Presented a new way to use bot services — `Dependencies` class. `Context` no more contains services (except `BotSettings`).  Dependencies is a singleton class, which can be used across app.