### PR TITLE
feat: set up LFG / Promo channels (closes #40)

### DIFF
--- a/lib/core/utils/event_parsers.dart
+++ b/lib/core/utils/event_parsers.dart
@@ -1,0 +1,19 @@
+import 'package:nyxx/nyxx.dart';
+
+/// Finds the first option with the given name and returns it.
+///
+/// Since the [InteractionOption] is a recursive structure, we need to search for the option in the list of options.
+T? findInOption<T>(String name, List<InteractionOption> option) {
+  for (final opt in option) {
+    if (opt.name == name) {
+      return opt.value as T;
+    }
+    if (opt.options != null) {
+      final result = findInOption<T>(name, opt.options!);
+      if (result != null) {
+        return result;
+      }
+    }
+  }
+  return null;
+}

--- a/lib/features/components/commands/create/create_command_component.dart
+++ b/lib/features/components/commands/create/create_command_component.dart
@@ -15,9 +15,15 @@ class CreateCommandComponent extends InteractorCommandComponent {
 
   @override
   Set<UpdateEvent> get updateWhen => {
-    UpdateEvent.timezonesUpdated,
-    UpdateEvent.activitiesUpdated,
-  };
+        UpdateEvent.timezonesUpdated,
+        UpdateEvent.activitiesUpdated,
+        UpdateEvent.lfgChannelUpdated,
+      };
+
+  @override
+  Future<bool> enabledWhen(Services services) async {
+    return await services.settings.getLFGChannel() != null;
+  }
 
   @override
   Future<ApplicationCommandBuilder> build(Services services) async {
@@ -83,6 +89,19 @@ class CreateCommandComponent extends InteractorCommandComponent {
     InteractionCreateEvent<ApplicationCommandInteraction> event,
     Services services,
   ) async {
+    final channelLfg = await services.settings.getLFGChannel();
+    if (channelLfg == null) {
+      print('LFG channel is not set');
+      return;
+    }
+
+    if (channelLfg != event.interaction.channelId?.value) {
+      return event.interaction.respond(
+        MessageBuilder(content: 'Команда доступна только в канале для поиска группы: <#$channelLfg>'),
+        isEphemeral: true,
+      );
+    }
+
     // in this handle in doesn't matter which type of activity was received,
     // so ignore `commandName` parameter
 

--- a/lib/features/settings/settings.dart
+++ b/lib/features/settings/settings.dart
@@ -51,22 +51,22 @@ class Settings {
   Future<void> updateLFGChannel(int? channelID) async {
     if (channelID == null) {
       await _database.guildSettingsDao.removeValue(lfgChannelKey);
-      return;
+    } else {
+      await _database.guildSettingsDao.saveValue(lfgChannelKey, channelID.toString());
     }
 
-    await _database.guildSettingsDao.saveValue(lfgChannelKey, channelID.toString());
-    _interactor.notifyUpdate({
-      UpdateEvent.lfgChannelUpdated,
-    });
+      _interactor.notifyUpdate({
+        UpdateEvent.lfgChannelUpdated,
+      });
   }
 
   Future<void> updatePromotesChannel(int? channelID) async {
     if (channelID == null) {
       await _database.guildSettingsDao.removeValue(promotesChannelKey);
-      return;
+    } else {
+      await _database.guildSettingsDao.saveValue(promotesChannelKey, channelID.toString());
     }
 
-    await _database.guildSettingsDao.saveValue(promotesChannelKey, channelID.toString());
     _interactor.notifyUpdate({
       UpdateEvent.promoChannelUpdated,
     });


### PR DESCRIPTION
This PR adds two new commands:
1. `admin set lfg_channel` — set up channel where /create command will work
2. `admin set promo_channel` — set up channel where bot notifies about LFGs

Other changes:
1. `create` command now updates when LFG channel updates. If LFG channel sets to null, command disables itself
2. `Interactor` now stores disabled commands and tries to re-register them when sync called