### PR TITLE
feat: add and remove activities (closes #39)

### DIFF
--- a/bin/bot.dart
+++ b/bin/bot.dart
@@ -8,6 +8,7 @@ import 'package:omega/core/utils/config.dart';
 import 'package:omega/core/utils/services.dart';
 import 'package:omega/features/components/buttons/join/join_message_component.dart';
 import 'package:omega/features/components/buttons/leave/leave_message_component.dart';
+import 'package:omega/features/components/commands/activity/activity_commands_component.dart';
 import 'package:omega/features/components/commands/admin/admin_commands_component.dart';
 import 'package:omega/features/components/commands/create/create_command_component.dart';
 import 'package:omega/features/components/commands/delete/delete_command_component.dart';
@@ -49,6 +50,7 @@ void runBot() => Future(() async {
         const JoinMessageComponent(),
         const LeaveMessageComponent(),
         const AdminCommandComponent(),
+        const ActivityCommandsComponent(),
       });
 
       await dependencies.interactor.forgetUnknown();

--- a/lib/features/components/commands/activity/activity_commands_component.dart
+++ b/lib/features/components/commands/activity/activity_commands_component.dart
@@ -1,0 +1,145 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:l/l.dart';
+
+import '../../../../core/data/models/activity_data.dart';
+import '../../../../core/utils/event_parsers.dart';
+import '../../../interactor/interactor_component.dart';
+import '../../../settings/settings.dart';
+
+class ActivityCommandsComponent extends InteractorCommandComponent {
+  const ActivityCommandsComponent();
+
+  @override
+  Future<ApplicationCommandBuilder> build(Services services) async {
+    return ApplicationCommandBuilder(
+      defaultMemberPermissions: Permissions.administrator,
+      name: 'activity',
+      description: 'Настройки активностей',
+      type: ApplicationCommandType.chatInput,
+      options: [
+        // add activity command
+        CommandOptionBuilder.subCommand(
+          name: 'add',
+          description: 'Добавить активность',
+          options: [
+            CommandOptionBuilder.string(
+              name: 'name',
+              description: 'Введите название активности',
+              isRequired: true,
+            ),
+            CommandOptionBuilder.integer(
+              name: 'members',
+              description: 'Введите максимальное количество участников',
+              isRequired: true,
+            ),
+            CommandOptionBuilder.string(
+              name: 'banner',
+              description: 'Введите URL баннера',
+              isRequired: false,
+            ),
+            CommandOptionBuilder.attachment(
+              name: 'banner_file',
+              description: 'Или загрузите баннер',
+              isRequired: false,
+            ),
+          ],
+        ),
+        // remove activity command
+        CommandOptionBuilder.subCommand(
+          name: 'remove',
+          description: 'Удалить активность',
+          options: [
+            CommandOptionBuilder.string(
+              name: 'название',
+              description: 'Введите название активности',
+              choices: await _getActivityChoices(services.settings),
+              isRequired: true,
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  Future<List<CommandOptionChoiceBuilder<String>>> _getActivityChoices(Settings settings) async {
+    final activities = await settings.getActivities();
+
+    return activities.map((e) => CommandOptionChoiceBuilder<String>(name: e.name, value: e.name)).toList();
+  }
+
+  @override
+  Future<void> handle(
+    String commandName,
+    InteractionCreateEvent<ApplicationCommandInteraction> event,
+    Services services,
+  ) async {
+    final member = event.interaction.member;
+
+    if (member == null) return; // refuse to work with bots
+    if (!(member.permissions?.has(Permissions.administrator) ?? false)) {
+      return; // Check if user is administrator
+    }
+
+    return switch (commandName) {
+      'activity add' => _handleActivityAdd(event, services),
+      'activity remove' => _handleActivityRemove(event, services),
+      _ => throw UnsupportedError('Unsupported command: $commandName'),
+    };
+  }
+
+  Future<void> _handleActivityAdd(
+    InteractionCreateEvent<ApplicationCommandInteraction> event,
+    Services services,
+  ) async {
+    unawaited(event.interaction.acknowledge(isEphemeral: false));
+    String? bannerPath;
+    final options = event.interaction.data.options!;
+    final activityName = findInOption<String>('name', options);
+    final maxMembers = findInOption<int>('members', options);
+    final bannerUrl = findInOption<String>('banner', options);
+    final bannerFileValue = findInOption<String>('banner_file', options);
+    final bannerFile = bannerFileValue != null ? Snowflake(int.parse(bannerFileValue)) : null;
+    final bannerFileAttachment = bannerFile != null ? event.interaction.data.resolved!.attachments![bannerFile] : null;
+
+    if (bannerFileAttachment != null) {
+      // download file to `/data/attachments/images` folder
+
+      l.d('[ActivityCommandsComponent] downloading BannerFileAttachment: ${bannerFileAttachment.url}');
+      final httpClient = HttpClient()..userAgent = 'omega_bot';
+      final request = await httpClient.getUrl(bannerFileAttachment.url);
+      final response = await request.close();
+      final file = File('data/attachments/images/${bannerFileAttachment.fileName}');
+      if (!file.existsSync()) {
+        await file.create(recursive: true);
+      }
+      await response.pipe(file.openWrite());
+      l.d('[ActivityCommandsComponent] downloaded BannerFileAttachment: ${file.path}');
+      bannerPath = file.uri.toFilePath();
+    } else {
+      bannerPath = bannerUrl;
+    }
+
+    final setting = services.settings;
+    await setting.addActivity(
+      ActivityData(
+        name: activityName!,
+        maxMembers: maxMembers!,
+        bannerUrl: bannerPath,
+        roles: null,
+        enabled: true,
+      ),
+    );
+
+    await event.interaction.respond(
+      MessageBuilder(content: 'Активность "$activityName" добавлена'),
+      isEphemeral: false,
+    );
+  }
+
+  Future<void> _handleActivityRemove(
+    InteractionCreateEvent<ApplicationCommandInteraction> event,
+    Services services,
+  ) async {}
+}

--- a/lib/features/components/commands/activity/activity_commands_component.dart
+++ b/lib/features/components/commands/activity/activity_commands_component.dart
@@ -12,6 +12,11 @@ class ActivityCommandsComponent extends InteractorCommandComponent {
   const ActivityCommandsComponent();
 
   @override
+  Set<UpdateEvent> get updateWhen => {
+        UpdateEvent.activitiesUpdated,
+      };
+
+  @override
   Future<ApplicationCommandBuilder> build(Services services) async {
     return ApplicationCommandBuilder(
       defaultMemberPermissions: Permissions.administrator,
@@ -52,7 +57,7 @@ class ActivityCommandsComponent extends InteractorCommandComponent {
           description: 'Удалить активность',
           options: [
             CommandOptionBuilder.string(
-              name: 'название',
+              name: 'name',
               description: 'Введите название активности',
               choices: await _getActivityChoices(services.settings),
               isRequired: true,
@@ -141,5 +146,15 @@ class ActivityCommandsComponent extends InteractorCommandComponent {
   Future<void> _handleActivityRemove(
     InteractionCreateEvent<ApplicationCommandInteraction> event,
     Services services,
-  ) async {}
+  ) async {
+    final activityName = findInOption<String>('name', event.interaction.data.options!);
+
+    final setting = services.settings;
+    await setting.removeActivity(activityName!);
+
+    await event.interaction.respond(
+      MessageBuilder(content: 'Активность "$activityName" удалена'),
+      isEphemeral: false,
+    );
+  }
 }

--- a/lib/features/interactor/interactor_component.dart
+++ b/lib/features/interactor/interactor_component.dart
@@ -14,9 +14,7 @@ enum UpdateEvent {
 
   /// Timezones were updated in the system.
   timezonesUpdated,
-
   lfgChannelUpdated,
-
   promoChannelUpdated,
 }
 
@@ -32,7 +30,11 @@ abstract class InteractorComponent<T extends Interaction<Object?>> {
   const InteractorComponent();
 
   /// Called when Interactor receives an event that this component should handle.
-  Future<void> handle(String commandName, InteractionCreateEvent<T> event, Services services);
+  Future<void> handle(
+    String commandName,
+    InteractionCreateEvent<T> event,
+    Services services,
+  );
 
   /// Called when Interactor wants to update components.
   ///

--- a/lib/features/settings/settings.dart
+++ b/lib/features/settings/settings.dart
@@ -55,9 +55,9 @@ class Settings {
       await _database.guildSettingsDao.saveValue(lfgChannelKey, channelID.toString());
     }
 
-      _interactor.notifyUpdate({
-        UpdateEvent.lfgChannelUpdated,
-      });
+    _interactor.notifyUpdate({
+      UpdateEvent.lfgChannelUpdated,
+    });
   }
 
   Future<void> updatePromotesChannel(int? channelID) async {

--- a/lib/features/settings/settings.dart
+++ b/lib/features/settings/settings.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import '../../core/data/models/activity_data.dart';
 import '../../core/utils/database/settings/db.dart';
 import '../interactor/interactor.dart';
@@ -113,10 +115,19 @@ class Settings {
   }
 
   Future<void> removeActivity(String name) async {
+    final activity = await _database.activitiesDao.getActivity(name);
     await _database.activitiesDao.removeActivity(name);
     _interactor.notifyUpdate({
       UpdateEvent.activitiesUpdated,
     });
+
+    final banner = activity.bannerUrl;
+    if (banner != null && !Uri.parse(banner).isScheme('https')) {
+      final file = File(banner);
+      if (file.existsSync()) {
+        file.deleteSync();
+      }
+    }
   }
 
   Future<void> addRoleToActivity(String activity, String role) async {


### PR DESCRIPTION
This PR adds two new commands:
1. `/activity add` — which adds a new activity to bot. There is support to upload banner via two methods: raw url and uploading image to bot
2. `/activity remove` — removes registered activity from bot. This also removes uploaded banner image 