### PR TITLE
Switch to Postgres and add API server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,8 @@ RUN dart compile exe bin/bot.dart -o bin/bot
 # Build final image with sqlite3 libs and the compiled bot binary
 FROM alpine:latest
 
-# Install the package with `libsqlite3.so`.
-RUN apk add --no-cache sqlite-dev
+# Install postgres and runtime dependencies
+RUN apk add --no-cache postgresql postgresql-client
 
 # TODO couldn't be bothered
 WORKDIR /app
@@ -22,5 +22,6 @@ COPY --from=build /runtime/ /
 COPY --from=build /app/bin/bot /app/bin/
 
 # Start server.
-CMD ["/app/bin/bot"]
+COPY docker-entrypoint.sh /app/
+CMD ["/app/docker-entrypoint.sh"]
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,12 @@ If the channel is not specified, notifications will not be created.
 3. Add the following environment variables to the docker container:
     - `OMEGA_SERVER_ID` — ID of the server where the bot will operate.
     - `OMEGA_TOKEN` — Bot token.
+    - `POSTGRES_USER` — Database user (default `omega`).
+    - `POSTGRES_PASSWORD` — Database password (default `omega`).
+    - `POSTGRES_DB` — Database name (default `omega`).
+    - `POSTGRES_HOST` — Host of postgres (default `localhost`).
+    - `POSTGRES_PORT` — Port of postgres (default `5432`).
+    - `API_PORT` — Port for API server (default `8080`).
 4. Run the container.
 5. Now invite bot to the server and configure it using commands (remember about settings LFG channel, or /create command
    will be disabled).

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+PGDATA="/app/data/db/postgres"
+mkdir -p "$PGDATA"
+if [ ! -d "$PGDATA/base" ]; then
+  initdb -D "$PGDATA"
+fi
+pg_ctl -D "$PGDATA" -o "-k /tmp" -w start
+/app/bin/bot

--- a/lib/api/api_server.dart
+++ b/lib/api/api_server.dart
@@ -1,0 +1,122 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:nyxx/nyxx.dart';
+import 'package:shelf/shelf.dart';
+import 'package:shelf/shelf_io.dart';
+import 'package:shelf_router/shelf_router.dart';
+
+import '../core/data/models/activity_data.dart';
+import '../core/utils/services.dart';
+
+class ApiServer {
+  ApiServer({required Services services}) : _services = services;
+
+  final Services _services;
+  HttpServer? _server;
+
+  Future<void> start() async {
+    final port = int.parse(Platform.environment['API_PORT'] ?? '8080');
+
+    final router = Router()
+      ..get('/health', _health)
+      ..get('/activities', _activities)
+      ..post('/activities', _addActivity)
+      ..delete('/activities/<name>', _removeActivity)
+      ..get('/settings', _settings)
+      ..put('/settings/lfg_channel', _setLfgChannel)
+      ..put('/settings/promotes_channel', _setPromotesChannel);
+
+    final handler = Pipeline()
+        .addMiddleware(logRequests())
+        .addMiddleware(_checkPermissions())
+        .addHandler(router);
+
+    _server = await serve(handler, InternetAddress.anyIPv4, port);
+  }
+
+  Middleware _checkPermissions() {
+    return (inner) {
+      return (request) async {
+        final id = request.headers['X-User-Id'];
+        if (id == null) return Response.forbidden('Missing user');
+        try {
+          final member = await _services.bot.guilds[_services.config.server]
+              .members
+              .get(Snowflake(int.parse(id)));
+          if (!member.permissions.hasPermission(Permissions.manageRoles)) {
+            return Response.forbidden('Forbidden');
+          }
+        } catch (_) {
+          return Response.forbidden('Forbidden');
+        }
+        return inner(request);
+      };
+    };
+  }
+
+  Response _health(Request request) => Response.ok('ok');
+
+  Future<Response> _activities(Request request) async {
+    final acts = await _services.settings.getActivities();
+    final data = [
+      for (final a in acts)
+        {
+          'name': a.name,
+          'maxMembers': a.maxMembers,
+          'banner': a.bannerUrl,
+          'enabled': a.enabled,
+          if (a.roles != null)
+            'roles': [
+              for (final r in a.roles!) {'role': r.role, 'qty': r.quantity}
+            ]
+        }
+    ];
+    return Response.ok(jsonEncode(data), headers: {'Content-Type': 'application/json'});
+  }
+
+  Future<Response> _addActivity(Request request) async {
+    final body = await request.readAsString();
+    final json = jsonDecode(body) as Map<String, dynamic>;
+    final roles = (json['roles'] as List?)
+        ?.map((e) => ActivityRole(role: e['role'], quantity: e['qty']))
+        .toList();
+    await _services.settings.addActivity(
+      ActivityData(
+        name: json['name'],
+        maxMembers: json['maxMembers'],
+        bannerUrl: json['banner'],
+        roles: roles,
+        enabled: json['enabled'] ?? true,
+      ),
+    );
+    return Response.ok('added');
+  }
+
+  Future<Response> _removeActivity(Request request, String name) async {
+    await _services.settings.removeActivity(name);
+    return Response.ok('removed');
+  }
+
+  Future<Response> _settings(Request request) async {
+    final lfg = await _services.settings.getLFGChannel();
+    final promo = await _services.settings.getPromotesChannel();
+    final tz = await _services.settings.getTimezones();
+    final data = {'lfg_channel': lfg, 'promotes_channel': promo, 'timezones': tz};
+    return Response.ok(jsonEncode(data), headers: {'Content-Type': 'application/json'});
+  }
+
+  Future<Response> _setLfgChannel(Request request) async {
+    final body = await request.readAsString();
+    final json = jsonDecode(body) as Map<String, dynamic>;
+    await _services.settings.updateLFGChannel(json['channel']);
+    return Response.ok('ok');
+  }
+
+  Future<Response> _setPromotesChannel(Request request) async {
+    final body = await request.readAsString();
+    final json = jsonDecode(body) as Map<String, dynamic>;
+    await _services.settings.updatePromotesChannel(json['channel']);
+    return Response.ok('ok');
+  }
+}

--- a/lib/core/utils/database/settings/db.dart
+++ b/lib/core/utils/database/settings/db.dart
@@ -1,7 +1,8 @@
 import 'dart:io';
 
 import 'package:drift/drift.dart';
-import 'package:drift/native.dart';
+import 'package:drift_postgres/drift_postgres.dart';
+import 'package:postgres/postgres.dart';
 
 import 'dao_activities.dart';
 import 'dao_guild_settings.dart';
@@ -37,7 +38,6 @@ class SettingsDatabase extends _$SettingsDatabase {
   @override
   MigrationStrategy get migration => MigrationStrategy(
         beforeOpen: (details) async {
-          await customStatement('PRAGMA foreign_keys = ON');
           if (details.wasCreated) await _setInitialData();
         },
       );
@@ -60,10 +60,21 @@ class SettingsDatabase extends _$SettingsDatabase {
   }
 }
 
-LazyDatabase _openConnection() {
-  return LazyDatabase(() async {
-    final file = File('data/db/settings.sqlite');
+PgDatabase _openConnection() {
+  final host = Platform.environment['POSTGRES_HOST'] ?? 'localhost';
+  final port = int.parse(Platform.environment['POSTGRES_PORT'] ?? '5432');
+  final user = Platform.environment['POSTGRES_USER'] ?? 'omega';
+  final password = Platform.environment['POSTGRES_PASSWORD'] ?? 'omega';
+  final db = Platform.environment['POSTGRES_DB'] ?? 'omega';
 
-    return NativeDatabase.createInBackground(file);
-  });
+  return PgDatabase(
+    endpoint: Endpoint(
+      host: host,
+      port: port,
+      database: db,
+      username: user,
+      password: password,
+    ),
+    settings: ConnectionSettings(sslMode: SslMode.disable),
+  );
 }

--- a/lib/core/utils/database/tables/posts.dart
+++ b/lib/core/utils/database/tables/posts.dart
@@ -4,7 +4,8 @@
 import 'dart:io';
 
 import 'package:drift/drift.dart';
-import 'package:drift/native.dart';
+import 'package:drift_postgres/drift_postgres.dart';
+import 'package:postgres/postgres.dart';
 
 import '../../../const/command_exceptions.dart';
 import '../../../data/models/activity_data.dart';
@@ -31,7 +32,11 @@ class PostsTable extends Table {
   IntColumn get maxMembers => integer().check(maxMembers.isBiggerThan(const Constant(0)))();
 
   /// A DateTime column named `date`. This stores the start date of the post.
-  DateTimeColumn get date => dateTime().check(date.isBiggerThan(currentDateAndTime))();
+  /// Can be null if time is not set yet.
+  DateTimeColumn get date => dateTime().nullable()();
+
+  /// Whether post should stay after firing and reset time.
+  BoolColumn get keepPost => boolean().withDefault(const Constant(false))();
 
   /// A integer column named `timezone`. This stores the timezone of the post.
   IntColumn get timezone => integer()();
@@ -182,10 +187,21 @@ class PostsDatabase extends _$PostsDatabase {
   }
 }
 
-LazyDatabase _openConnection() {
-  return LazyDatabase(() async {
-    final file = File('data/db/posts.sqlite');
+PgDatabase _openConnection() {
+  final host = Platform.environment['POSTGRES_HOST'] ?? 'localhost';
+  final port = int.parse(Platform.environment['POSTGRES_PORT'] ?? '5432');
+  final user = Platform.environment['POSTGRES_USER'] ?? 'omega';
+  final password = Platform.environment['POSTGRES_PASSWORD'] ?? 'omega';
+  final db = Platform.environment['POSTGRES_DB'] ?? 'omega';
 
-    return NativeDatabase.createInBackground(file);
-  });
+  return PgDatabase(
+    endpoint: Endpoint(
+      host: host,
+      port: port,
+      database: db,
+      username: user,
+      password: password,
+    ),
+    settings: ConnectionSettings(sslMode: SslMode.disable),
+  );
 }

--- a/lib/core/utils/database/tables/posts.g.dart
+++ b/lib/core/utils/database/tables/posts.g.dart
@@ -44,10 +44,18 @@ class $PostsTableTable extends PostsTable
   static const VerificationMeta _dateMeta = const VerificationMeta('date');
   @override
   late final GeneratedColumn<DateTime> date = GeneratedColumn<DateTime>(
-      'date', aliasedName, false,
-      check: () => date.isBiggerThan(currentDateAndTime),
-      type: DriftSqlType.dateTime,
-      requiredDuringInsert: true);
+      'date', aliasedName, true,
+      type: DriftSqlType.dateTime, requiredDuringInsert: false);
+  static const VerificationMeta _keepPostMeta =
+      const VerificationMeta('keepPost');
+  @override
+  late final GeneratedColumn<bool> keepPost = GeneratedColumn<bool>(
+      'keep_post', aliasedName, false,
+      type: DriftSqlType.bool,
+      requiredDuringInsert: false,
+      defaultConstraints:
+          GeneratedColumn.constraintIsAlways('CHECK ("keep_post" IN (0, 1))'),
+      defaultValue: const Constant(false));
   static const VerificationMeta _timezoneMeta =
       const VerificationMeta('timezone');
   @override
@@ -80,6 +88,7 @@ class $PostsTableTable extends PostsTable
         author,
         maxMembers,
         date,
+        keepPost,
         timezone,
         createdAt,
         isDeleted
@@ -133,8 +142,10 @@ class $PostsTableTable extends PostsTable
     if (data.containsKey('date')) {
       context.handle(
           _dateMeta, date.isAcceptableOrUnknown(data['date']!, _dateMeta));
-    } else if (isInserting) {
-      context.missing(_dateMeta);
+    }
+    if (data.containsKey('keep_post')) {
+      context.handle(_keepPostMeta,
+          keepPost.isAcceptableOrUnknown(data['keep_post']!, _keepPostMeta));
     }
     if (data.containsKey('timezone')) {
       context.handle(_timezoneMeta,
@@ -170,7 +181,9 @@ class $PostsTableTable extends PostsTable
       maxMembers: attachedDatabase.typeMapping
           .read(DriftSqlType.int, data['${effectivePrefix}max_members'])!,
       date: attachedDatabase.typeMapping
-          .read(DriftSqlType.dateTime, data['${effectivePrefix}date'])!,
+          .read(DriftSqlType.dateTime, data['${effectivePrefix}date']),
+      keepPost: attachedDatabase.typeMapping
+          .read(DriftSqlType.bool, data['${effectivePrefix}keep_post'])!,
       timezone: attachedDatabase.typeMapping
           .read(DriftSqlType.int, data['${effectivePrefix}timezone'])!,
       createdAt: attachedDatabase.typeMapping
@@ -203,7 +216,11 @@ class PostsTableData extends DataClass implements Insertable<PostsTableData> {
   final int maxMembers;
 
   /// A DateTime column named `date`. This stores the start date of the post.
-  final DateTime date;
+  /// Can be null if time is not set yet.
+  final DateTime? date;
+
+  /// Whether post should stay after firing and reset time.
+  final bool keepPost;
 
   /// A integer column named `timezone`. This stores the timezone of the post.
   final int timezone;
@@ -219,7 +236,8 @@ class PostsTableData extends DataClass implements Insertable<PostsTableData> {
       required this.description,
       required this.author,
       required this.maxMembers,
-      required this.date,
+      this.date,
+      required this.keepPost,
       required this.timezone,
       required this.createdAt,
       required this.isDeleted});
@@ -231,7 +249,10 @@ class PostsTableData extends DataClass implements Insertable<PostsTableData> {
     map['description'] = Variable<String>(description);
     map['author'] = Variable<int>(author);
     map['max_members'] = Variable<int>(maxMembers);
-    map['date'] = Variable<DateTime>(date);
+    if (!nullToAbsent || date != null) {
+      map['date'] = Variable<DateTime>(date);
+    }
+    map['keep_post'] = Variable<bool>(keepPost);
     map['timezone'] = Variable<int>(timezone);
     map['created_at'] = Variable<DateTime>(createdAt);
     map['is_deleted'] = Variable<bool>(isDeleted);
@@ -245,7 +266,8 @@ class PostsTableData extends DataClass implements Insertable<PostsTableData> {
       description: Value(description),
       author: Value(author),
       maxMembers: Value(maxMembers),
-      date: Value(date),
+      date: date == null && nullToAbsent ? const Value.absent() : Value(date),
+      keepPost: Value(keepPost),
       timezone: Value(timezone),
       createdAt: Value(createdAt),
       isDeleted: Value(isDeleted),
@@ -261,7 +283,8 @@ class PostsTableData extends DataClass implements Insertable<PostsTableData> {
       description: serializer.fromJson<String>(json['description']),
       author: serializer.fromJson<int>(json['author']),
       maxMembers: serializer.fromJson<int>(json['maxMembers']),
-      date: serializer.fromJson<DateTime>(json['date']),
+      date: serializer.fromJson<DateTime?>(json['date']),
+      keepPost: serializer.fromJson<bool>(json['keepPost']),
       timezone: serializer.fromJson<int>(json['timezone']),
       createdAt: serializer.fromJson<DateTime>(json['createdAt']),
       isDeleted: serializer.fromJson<bool>(json['isDeleted']),
@@ -276,7 +299,8 @@ class PostsTableData extends DataClass implements Insertable<PostsTableData> {
       'description': serializer.toJson<String>(description),
       'author': serializer.toJson<int>(author),
       'maxMembers': serializer.toJson<int>(maxMembers),
-      'date': serializer.toJson<DateTime>(date),
+      'date': serializer.toJson<DateTime?>(date),
+      'keepPost': serializer.toJson<bool>(keepPost),
       'timezone': serializer.toJson<int>(timezone),
       'createdAt': serializer.toJson<DateTime>(createdAt),
       'isDeleted': serializer.toJson<bool>(isDeleted),
@@ -289,7 +313,8 @@ class PostsTableData extends DataClass implements Insertable<PostsTableData> {
           String? description,
           int? author,
           int? maxMembers,
-          DateTime? date,
+          Value<DateTime?> date = const Value.absent(),
+          bool? keepPost,
           int? timezone,
           DateTime? createdAt,
           bool? isDeleted}) =>
@@ -299,7 +324,8 @@ class PostsTableData extends DataClass implements Insertable<PostsTableData> {
         description: description ?? this.description,
         author: author ?? this.author,
         maxMembers: maxMembers ?? this.maxMembers,
-        date: date ?? this.date,
+        date: date.present ? date.value : this.date,
+        keepPost: keepPost ?? this.keepPost,
         timezone: timezone ?? this.timezone,
         createdAt: createdAt ?? this.createdAt,
         isDeleted: isDeleted ?? this.isDeleted,
@@ -313,6 +339,7 @@ class PostsTableData extends DataClass implements Insertable<PostsTableData> {
           ..write('author: $author, ')
           ..write('maxMembers: $maxMembers, ')
           ..write('date: $date, ')
+          ..write('keepPost: $keepPost, ')
           ..write('timezone: $timezone, ')
           ..write('createdAt: $createdAt, ')
           ..write('isDeleted: $isDeleted')
@@ -322,7 +349,7 @@ class PostsTableData extends DataClass implements Insertable<PostsTableData> {
 
   @override
   int get hashCode => Object.hash(postMessageId, title, description, author,
-      maxMembers, date, timezone, createdAt, isDeleted);
+      maxMembers, date, keepPost, timezone, createdAt, isDeleted);
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -333,6 +360,7 @@ class PostsTableData extends DataClass implements Insertable<PostsTableData> {
           other.author == this.author &&
           other.maxMembers == this.maxMembers &&
           other.date == this.date &&
+          other.keepPost == this.keepPost &&
           other.timezone == this.timezone &&
           other.createdAt == this.createdAt &&
           other.isDeleted == this.isDeleted);
@@ -344,7 +372,8 @@ class PostsTableCompanion extends UpdateCompanion<PostsTableData> {
   final Value<String> description;
   final Value<int> author;
   final Value<int> maxMembers;
-  final Value<DateTime> date;
+  final Value<DateTime?> date;
+  final Value<bool> keepPost;
   final Value<int> timezone;
   final Value<DateTime> createdAt;
   final Value<bool> isDeleted;
@@ -356,6 +385,7 @@ class PostsTableCompanion extends UpdateCompanion<PostsTableData> {
     this.author = const Value.absent(),
     this.maxMembers = const Value.absent(),
     this.date = const Value.absent(),
+    this.keepPost = const Value.absent(),
     this.timezone = const Value.absent(),
     this.createdAt = const Value.absent(),
     this.isDeleted = const Value.absent(),
@@ -367,7 +397,8 @@ class PostsTableCompanion extends UpdateCompanion<PostsTableData> {
     required String description,
     required int author,
     required int maxMembers,
-    required DateTime date,
+    this.date = const Value.absent(),
+    this.keepPost = const Value.absent(),
     required int timezone,
     this.createdAt = const Value.absent(),
     this.isDeleted = const Value.absent(),
@@ -377,7 +408,6 @@ class PostsTableCompanion extends UpdateCompanion<PostsTableData> {
         description = Value(description),
         author = Value(author),
         maxMembers = Value(maxMembers),
-        date = Value(date),
         timezone = Value(timezone);
   static Insertable<PostsTableData> custom({
     Expression<int>? postMessageId,
@@ -386,6 +416,7 @@ class PostsTableCompanion extends UpdateCompanion<PostsTableData> {
     Expression<int>? author,
     Expression<int>? maxMembers,
     Expression<DateTime>? date,
+    Expression<bool>? keepPost,
     Expression<int>? timezone,
     Expression<DateTime>? createdAt,
     Expression<bool>? isDeleted,
@@ -398,6 +429,7 @@ class PostsTableCompanion extends UpdateCompanion<PostsTableData> {
       if (author != null) 'author': author,
       if (maxMembers != null) 'max_members': maxMembers,
       if (date != null) 'date': date,
+      if (keepPost != null) 'keep_post': keepPost,
       if (timezone != null) 'timezone': timezone,
       if (createdAt != null) 'created_at': createdAt,
       if (isDeleted != null) 'is_deleted': isDeleted,
@@ -411,7 +443,8 @@ class PostsTableCompanion extends UpdateCompanion<PostsTableData> {
       Value<String>? description,
       Value<int>? author,
       Value<int>? maxMembers,
-      Value<DateTime>? date,
+      Value<DateTime?>? date,
+      Value<bool>? keepPost,
       Value<int>? timezone,
       Value<DateTime>? createdAt,
       Value<bool>? isDeleted,
@@ -423,6 +456,7 @@ class PostsTableCompanion extends UpdateCompanion<PostsTableData> {
       author: author ?? this.author,
       maxMembers: maxMembers ?? this.maxMembers,
       date: date ?? this.date,
+      keepPost: keepPost ?? this.keepPost,
       timezone: timezone ?? this.timezone,
       createdAt: createdAt ?? this.createdAt,
       isDeleted: isDeleted ?? this.isDeleted,
@@ -451,6 +485,9 @@ class PostsTableCompanion extends UpdateCompanion<PostsTableData> {
     if (date.present) {
       map['date'] = Variable<DateTime>(date.value);
     }
+    if (keepPost.present) {
+      map['keep_post'] = Variable<bool>(keepPost.value);
+    }
     if (timezone.present) {
       map['timezone'] = Variable<int>(timezone.value);
     }
@@ -475,6 +512,7 @@ class PostsTableCompanion extends UpdateCompanion<PostsTableData> {
           ..write('author: $author, ')
           ..write('maxMembers: $maxMembers, ')
           ..write('date: $date, ')
+          ..write('keepPost: $keepPost, ')
           ..write('timezone: $timezone, ')
           ..write('createdAt: $createdAt, ')
           ..write('isDeleted: $isDeleted, ')
@@ -745,7 +783,8 @@ typedef $$PostsTableTableInsertCompanionBuilder = PostsTableCompanion Function({
   required String description,
   required int author,
   required int maxMembers,
-  required DateTime date,
+  Value<DateTime?> date,
+  Value<bool> keepPost,
   required int timezone,
   Value<DateTime> createdAt,
   Value<bool> isDeleted,
@@ -757,7 +796,8 @@ typedef $$PostsTableTableUpdateCompanionBuilder = PostsTableCompanion Function({
   Value<String> description,
   Value<int> author,
   Value<int> maxMembers,
-  Value<DateTime> date,
+  Value<DateTime?> date,
+  Value<bool> keepPost,
   Value<int> timezone,
   Value<DateTime> createdAt,
   Value<bool> isDeleted,
@@ -789,7 +829,8 @@ class $$PostsTableTableTableManager extends RootTableManager<
             Value<String> description = const Value.absent(),
             Value<int> author = const Value.absent(),
             Value<int> maxMembers = const Value.absent(),
-            Value<DateTime> date = const Value.absent(),
+            Value<DateTime?> date = const Value.absent(),
+            Value<bool> keepPost = const Value.absent(),
             Value<int> timezone = const Value.absent(),
             Value<DateTime> createdAt = const Value.absent(),
             Value<bool> isDeleted = const Value.absent(),
@@ -802,6 +843,7 @@ class $$PostsTableTableTableManager extends RootTableManager<
             author: author,
             maxMembers: maxMembers,
             date: date,
+            keepPost: keepPost,
             timezone: timezone,
             createdAt: createdAt,
             isDeleted: isDeleted,
@@ -813,7 +855,8 @@ class $$PostsTableTableTableManager extends RootTableManager<
             required String description,
             required int author,
             required int maxMembers,
-            required DateTime date,
+            Value<DateTime?> date = const Value.absent(),
+            Value<bool> keepPost = const Value.absent(),
             required int timezone,
             Value<DateTime> createdAt = const Value.absent(),
             Value<bool> isDeleted = const Value.absent(),
@@ -826,6 +869,7 @@ class $$PostsTableTableTableManager extends RootTableManager<
             author: author,
             maxMembers: maxMembers,
             date: date,
+            keepPost: keepPost,
             timezone: timezone,
             createdAt: createdAt,
             isDeleted: isDeleted,
@@ -876,6 +920,11 @@ class $$PostsTableTableFilterComposer
 
   ColumnFilters<DateTime> get date => $state.composableBuilder(
       column: $state.table.date,
+      builder: (column, joinBuilders) =>
+          ColumnFilters(column, joinBuilders: joinBuilders));
+
+  ColumnFilters<bool> get keepPost => $state.composableBuilder(
+      column: $state.table.keepPost,
       builder: (column, joinBuilders) =>
           ColumnFilters(column, joinBuilders: joinBuilders));
 
@@ -938,6 +987,11 @@ class $$PostsTableTableOrderingComposer
 
   ColumnOrderings<DateTime> get date => $state.composableBuilder(
       column: $state.table.date,
+      builder: (column, joinBuilders) =>
+          ColumnOrderings(column, joinBuilders: joinBuilders));
+
+  ColumnOrderings<bool> get keepPost => $state.composableBuilder(
+      column: $state.table.keepPost,
       builder: (column, joinBuilders) =>
           ColumnOrderings(column, joinBuilders: joinBuilders));
 

--- a/lib/core/utils/services.dart
+++ b/lib/core/utils/services.dart
@@ -6,6 +6,7 @@ import '../../features/lfg_manager/lfg_message_builder.dart';
 import '../../features/promoter/promoter.dart';
 import '../../features/scheduler/scheduler.dart';
 import '../../features/settings/settings.dart';
+import '../../api/api_server.dart';
 import 'config.dart';
 import 'database/settings/db.dart';
 import 'database/tables/posts.dart';
@@ -82,6 +83,9 @@ final class Services {
       settings: settings,
     );
 
+    services.apiServer = ApiServer(services: services);
+    await services.apiServer!.start();
+
     return _instance = services;
   }
 
@@ -103,4 +107,6 @@ final class Services {
   final NyxxGateway bot;
 
   final Settings settings;
+
+  ApiServer? apiServer;
 }

--- a/lib/features/scheduler/scheduler.dart
+++ b/lib/features/scheduler/scheduler.dart
@@ -57,13 +57,15 @@ final class PostScheduler {
     final now = DateTime.now();
     final posts = await _database.getAllPosts();
     for (final post in posts) {
+      final date = post.date;
+      if (date == null) continue;
       // skip post if difference between now and post time is more than 1 hour
-      if (now.difference(post.date).inHours > 1) {
+      if (now.difference(date).inHours > 1) {
         l.i('[Scheduler] Schedule post with id ${post.postMessageId} will be deleted because it is too old');
         await _deleteLFGPostAfter(postID: post.postMessageId, duration: Duration.zero);
       }
 
-      _posts[post.postMessageId] = post.date;
+      _posts[post.postMessageId] = date;
     }
   }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,23 +5,23 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: "5aaf60d96c4cd00fe7f21594b5ad6a1b699c80a27420f8a837f4d68473ef09e3"
+      sha256: "16e298750b6d0af7ce8a3ba7c18c69c3785d11b15ec83f6dcd0ad2a0009b3cab"
       url: "https://pub.dev"
     source: hosted
-    version: "68.0.0"
+    version: "76.0.0"
   _macros:
     dependency: transitive
     description: dart
     source: sdk
-    version: "0.1.0"
+    version: "0.3.3"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "21f1d3720fd1c70316399d5e2bccaebb415c434592d778cce8acb967b8578808"
+      sha256: "1f14db053a8c23e260789e9b0980fa27f2680dd640932cae5e1137cce0e46e1e"
       url: "https://pub.dev"
     source: hosted
-    version: "6.5.0"
+    version: "6.11.0"
   analyzer_plugin:
     dependency: transitive
     description:
@@ -42,10 +42,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
+      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
       url: "https://pub.dev"
     source: hosted
-    version: "2.11.0"
+    version: "2.13.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -54,6 +54,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
+  buffer:
+    dependency: transitive
+    description:
+      name: buffer
+      sha256: "389da2ec2c16283c8787e0adaede82b1842102f8c8aae2f49003a766c5c6b3d1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.3"
   build:
     dependency: transitive
     description:
@@ -122,10 +130,10 @@ packages:
     dependency: transitive
     description:
       name: charcode
-      sha256: fb98c0f6d12c920a02ee2d998da788bca066ca5f148492b7085ee23372b12306
+      sha256: fb0f1107cac15a5ea6ef0a6ef71a807b9e4267c713bb93e00e92d737cc8dbd8a
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.4.0"
   checked_yaml:
     dependency: transitive
     description:
@@ -162,10 +170,10 @@ packages:
     dependency: "direct main"
     description:
       name: collection
-      sha256: a1ace0a119f20aabc852d165077c036cd864315bd99b7eaa10a60100341941bf
+      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
       url: "https://pub.dev"
     source: hosted
-    version: "1.19.0"
+    version: "1.19.1"
   convert:
     dependency: transitive
     description:
@@ -186,10 +194,10 @@ packages:
     dependency: transitive
     description:
       name: crypto
-      sha256: ff625774173754681d66daaf4a448684fb04b78f902da9cb3d308c19cc5e8bab
+      sha256: "1e445881f28f22d6140f181e07737b22f1e099a5e1ff94b0af2f9e4a463f4855"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "3.0.6"
   dart_style:
     dependency: transitive
     description:
@@ -214,6 +222,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.18.0"
+  drift_postgres:
+    dependency: "direct main"
+    description:
+      name: drift_postgres
+      sha256: ce1fe060b2d329b45423892501355f1982e099faba9e75bcba307f390b1b20a3
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.0"
   eterl:
     dependency: transitive
     description:
@@ -278,6 +294,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
+  http_methods:
+    dependency: transitive
+    description:
+      name: http_methods
+      sha256: "6bccce8f1ec7b5d701e7921dca35e202d425b57e317ba1a37f2638590e29e566"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
   http_multi_server:
     dependency: transitive
     description:
@@ -354,10 +378,10 @@ packages:
     dependency: transitive
     description:
       name: macros
-      sha256: "12e8a9842b5a7390de7a781ec63d793527582398d16ea26c60fed58833c9ae79"
+      sha256: "1d9e801cd66f7ea3663c45fc708450db1fa57f988142c64289142c9b7ee80656"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.0-main.0"
+    version: "0.1.3-main.0"
   matcher:
     dependency: transitive
     description:
@@ -370,10 +394,10 @@ packages:
     dependency: "direct main"
     description:
       name: meta
-      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.15.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -430,6 +454,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.1"
+  postgres:
+    dependency: "direct main"
+    description:
+      name: postgres
+      sha256: "9aaa6f4872956adef653535a4e2133b167465c1a68c22b9bd0744ef1244e9393"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.5.6"
   pub_semver:
     dependency: transitive
     description:
@@ -470,8 +502,24 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
-  shelf:
+  sasl_scram:
     dependency: transitive
+    description:
+      name: sasl_scram
+      sha256: a47207a436eb650f8fdcf54a2e2587b850dc3caef9973ce01f332b07a6fc9cb9
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.1"
+  saslprep:
+    dependency: transitive
+    description:
+      name: saslprep
+      sha256: "3d421d10be9513bf4459c17c5e70e7b8bc718c9fc5ad4ba5eb4f5fd27396f740"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.3"
+  shelf:
+    dependency: "direct main"
     description:
       name: shelf
       sha256: e7dd780a7ffb623c57850b33f43309312fc863fb6aa3d276a754bb299839ef12
@@ -486,6 +534,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.2"
+  shelf_router:
+    dependency: "direct main"
+    description:
+      name: shelf_router
+      sha256: f5e5d492440a7fb165fe1e2e1a623f31f734d3370900070b2b1e0d0428d59864
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.4"
   shelf_static:
     dependency: transitive
     description:
@@ -534,8 +590,16 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.10.0"
+  sprintf:
+    dependency: transitive
+    description:
+      name: sprintf
+      sha256: "1fc9ffe69d4df602376b52949af107d8f5703b77cda567c4d7d86a0693120f23"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.0"
   sqlite3:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: sqlite3
       sha256: "6d17989c0b06a5870b2190d391925186f944cb943e5262d0d3f778fcfca3bc6e"
@@ -554,18 +618,18 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.1"
+    version: "1.12.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
+      sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
   stream_transform:
     dependency: transitive
     description:
@@ -630,6 +694,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.2"
+  unorm_dart:
+    dependency: transitive
+    description:
+      name: unorm_dart
+      sha256: "23d8bf65605401a6a32cff99435fed66ef3dab3ddcad3454059165df46496a3b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.0"
+  uuid:
+    dependency: transitive
+    description:
+      name: uuid
+      sha256: a5be9ef6618a7ac1e964353ef476418026db906c4facdedaa299b7a2e71690ff
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.5.1"
   vm_service:
     dependency: transitive
     description:
@@ -687,4 +767,4 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.4.3 <4.0.0"
+  dart: ">=3.5.0 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,12 +18,15 @@ dependencies:
 
   # database
   drift: ^2.18.0
-  sqlite3: ^2.4.4
-
+  drift_postgres: ^1.3.0
+  postgres: ^3.5.6
+  
   # utils
   l: ^4.0.2
   meta: ^1.15.0
   collection: ^1.19.0
+  shelf: ^1.4.2
+  shelf_router: ^1.1.4
 
   # localization
   intl: ^0.19.0


### PR DESCRIPTION
## Summary
- migrate databases to Postgres
- prepare posts table for optional date and persistent posts
- add lightweight HTTP API with shelf
- start API from `Services` and expose via `API_PORT`
- install Postgres in Docker image and add entrypoint
- document new environment variables

## Testing
- `dart pub get`
- `dart run build_runner build --delete-conflicting-outputs`
- `dart test`

------
https://chatgpt.com/codex/tasks/task_e_683f884d326c832084bfb76ce5e3bc8a